### PR TITLE
Expose dataset paths in monitor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,32 @@ use consistent inputs.
 Run `python scripts/run_training.py` to train a churn model using the processed
 datasets. The script expects `data/processed/processed_features.csv` and
 `data/processed/processed_target.csv` by default, but you can override these
-paths with `--X_path` and `--y_path`.
+paths with `--X_path` and `--y_path`.  Additional logistic regression
+hyperparameters are exposed as CLI flags, for example:
+
+```bash
+python scripts/run_training.py \
+  --solver saga --C 0.5 --penalty l1 --random_state 7 --max_iter 200 --test_size 0.3
+```
 ## Monitoring and Retraining
 Run `python -m src.monitor_performance` to evaluate the current model on the processed dataset. If accuracy drops below 0.8 the model will automatically retrain. A convenience wrapper is also available via `python scripts/run_monitor.py`.
-The accuracy threshold can be overridden with the `CHURN_THRESHOLD` environment variable or the `--threshold` argument of `run_monitor.py`.
+The accuracy threshold can be overridden with the `CHURN_THRESHOLD` environment variable or the `--threshold` argument of `run_monitor.py`. The same hyperparameters as `run_training.py` can also be supplied when retraining through this script. You can also override the processed data paths with `--X_path` and `--y_path`:
+
+```bash
+python scripts/run_monitor.py \
+  --threshold 0.85 \
+  --solver saga --C 0.8 --penalty l1 --random_state 21 --max_iter 250 --test_size 0.25
+```
 
 ## Evaluating a Trained Model
-Use `python scripts/run_evaluation.py` to compute accuracy and F1-score of the current model on the processed dataset. Pass `--output metrics.json` to save the metrics to a JSON file.
+Use `python scripts/run_evaluation.py` to compute accuracy and F1-score of the current model on the processed dataset. Pass `--output metrics.json` to save the metrics to a JSON file. Include the `--detailed` flag to also generate a full classification report.
 If the model file is missing, the evaluation script will automatically download it from MLflow using the saved run ID (or the `MLFLOW_RUN_ID` environment variable). You can also specify the run directly with `--run_id <RUN_ID>`.
 The evaluation step also logs these metrics to MLflow so you can monitor performance over time.
+For a more comprehensive breakdown of precision and recall per class, run:
+
+```bash
+python scripts/run_evaluation.py --detailed --output detailed_metrics.json
+```
 
 ## Batch Prediction
 Use `python scripts/run_prediction.py <input_csv> --output_csv predictions.csv` to generate churn predictions for a CSV file of processed features. The script adds `prediction` and `probability` columns and saves the result to the specified output file.
@@ -83,6 +100,12 @@ The `run_prediction.py` script relies on the same mechanism, so batch prediction
 
 ## End-to-End Pipeline
 Run `python scripts/run_pipeline.py` to execute preprocessing, training, and evaluation in one step. This recreates the processed datasets, trains the model, evaluates it, and prints the resulting metrics.
+You can pass the same hyperparameters used by `run_training.py` to experiment with different model settings:
+
+```bash
+python scripts/run_pipeline.py \
+  --solver saga --C 0.5 --penalty l1 --random_state 7 --max_iter 200 --test_size 0.3
+```
 
 ## How to Contribute (and test Jules)
 Jules, our Async Development Agent, will assist in building out features, tests, and MLOps components. Please create clear issues.

--- a/scripts/run_monitor.py
+++ b/scripts/run_monitor.py
@@ -16,9 +16,35 @@ def main():
         type=float,
         help="Accuracy threshold below which to retrain. Overrides CHURN_THRESHOLD env var.",
     )
+    parser.add_argument(
+        "--X_path",
+        default="data/processed/processed_features.csv",
+        help="Path to processed feature CSV",
+    )
+    parser.add_argument(
+        "--y_path",
+        default="data/processed/processed_target.csv",
+        help="Path to processed target CSV",
+    )
+    parser.add_argument("--solver", default="liblinear", help="Logistic regression solver")
+    parser.add_argument("--C", type=float, default=1.0, help="Inverse of regularization strength")
+    parser.add_argument("--penalty", default="l2", help="Penalty (regularization) type")
+    parser.add_argument("--random_state", type=int, default=42, help="Random seed for training")
+    parser.add_argument("--max_iter", type=int, default=100, help="Maximum number of iterations")
+    parser.add_argument("--test_size", type=float, default=0.2, help="Proportion of dataset for testing")
     args = parser.parse_args()
 
-    monitor_and_retrain(threshold=args.threshold)
+    monitor_and_retrain(
+        threshold=args.threshold,
+        X_path=args.X_path,
+        y_path=args.y_path,
+        solver=args.solver,
+        C=args.C,
+        penalty=args.penalty,
+        random_state=args.random_state,
+        max_iter=args.max_iter,
+        test_size=args.test_size,
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -12,8 +12,40 @@ from scripts.run_evaluation import run_evaluation
 from src.constants import PROCESSED_FEATURES_PATH, PROCESSED_TARGET_PATH
 
 
-def run_pipeline(raw_path: str = 'data/raw/customer_data.csv'):
-    """Run preprocessing, training, and evaluation as a single pipeline."""
+def run_pipeline(
+    raw_path: str = 'data/raw/customer_data.csv',
+    *,
+    solver: str = 'liblinear',
+    C: float = 1.0,
+    penalty: str = 'l2',
+    random_state: int = 42,
+    max_iter: int = 100,
+    test_size: float = 0.2,
+):
+    """Run preprocessing, training, and evaluation as a single pipeline.
+
+Parameters
+----------
+raw_path : str, optional
+    Path to the raw customer CSV file. Defaults to ``'data/raw/customer_data.csv'``.
+solver : str, optional
+    Solver for :class:`~sklearn.linear_model.LogisticRegression`. Defaults to ``"liblinear"``.
+    C : float, optional
+        Inverse of regularization strength. Defaults to ``1.0``.
+    penalty : str, optional
+        Penalty (regularization) type. Defaults to ``"l2"``.
+    random_state : int, optional
+        Random seed for reproducibility. Defaults to ``42``.
+max_iter : int, optional
+    Maximum optimization iterations. Defaults to ``100``.
+test_size : float, optional
+    Proportion of the dataset to include in the test split. Defaults to ``0.2``.
+
+Returns
+-------
+    tuple[float, float]
+        The accuracy and F1-score of the trained model.
+    """
     processed_features = PROCESSED_FEATURES_PATH
     processed_target = PROCESSED_TARGET_PATH
 
@@ -22,7 +54,16 @@ def run_pipeline(raw_path: str = 'data/raw/customer_data.csv'):
     X_proc.to_csv(processed_features, index=False)
     pd.DataFrame(y_proc, columns=['Churn']).to_csv(processed_target, index=False)
 
-    model_path, run_id = run_training(processed_features, processed_target)
+    model_path, run_id = run_training(
+        processed_features,
+        processed_target,
+        solver=solver,
+        C=C,
+        penalty=penalty,
+        random_state=random_state,
+        max_iter=max_iter,
+        test_size=test_size,
+    )
     accuracy, f1 = run_evaluation(model_path, processed_features, processed_target, run_id=run_id)
     print(f"Pipeline completed. Accuracy: {accuracy:.4f}, F1-score: {f1:.4f}")
     return accuracy, f1
@@ -31,8 +72,22 @@ def run_pipeline(raw_path: str = 'data/raw/customer_data.csv'):
 def main():
     parser = argparse.ArgumentParser(description="Run full churn prediction pipeline")
     parser.add_argument('--raw_path', default='data/raw/customer_data.csv', help='Path to raw customer CSV')
+    parser.add_argument('--solver', default='liblinear', help='Logistic regression solver')
+    parser.add_argument('--C', type=float, default=1.0, help='Inverse of regularization strength')
+    parser.add_argument('--penalty', default='l2', help='Penalty (regularization) type')
+    parser.add_argument('--random_state', type=int, default=42, help='Random seed for training')
+    parser.add_argument('--max_iter', type=int, default=100, help='Maximum number of iterations')
+    parser.add_argument('--test_size', type=float, default=0.2, help='Proportion of dataset for testing')
     args = parser.parse_args()
-    run_pipeline(args.raw_path)
+    run_pipeline(
+        args.raw_path,
+        solver=args.solver,
+        C=args.C,
+        penalty=args.penalty,
+        random_state=args.random_state,
+        max_iter=args.max_iter,
+        test_size=args.test_size,
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -13,8 +13,39 @@ from src.constants import PROCESSED_FEATURES_PATH, PROCESSED_TARGET_PATH
 def run_training(
     X_path: str = PROCESSED_FEATURES_PATH,
     y_path: str = PROCESSED_TARGET_PATH,
+    *,
+    solver: str = "liblinear",
+    C: float = 1.0,
+    penalty: str = "l2",
+    random_state: int = 42,
+    max_iter: int = 100,
+    test_size: float = 0.2,
 ):
-    """Train the churn model using the provided processed datasets."""
+    """Train the churn model using the provided processed datasets.
+
+    Parameters
+    ----------
+    X_path, y_path : str
+        Paths to the processed feature and target CSV files.
+    solver : str, optional
+        Logistic regression solver, by default ``"liblinear"``.
+    C : float, optional
+        Inverse of regularization strength, by default ``1.0``.
+    penalty : str, optional
+        Penalty (regularization) to use. Defaults to ``"l2"``.
+    random_state : int, optional
+        Random seed for reproducibility, by default ``42``.
+    max_iter : int, optional
+        Maximum number of iterations for optimization, by default ``100``.
+    test_size : float, optional
+        Proportion of the dataset to include in the test split, by default
+        ``0.2``.
+
+    Returns
+    -------
+    tuple[str, str]
+        The path to the saved model and the MLflow run ID.
+    """
     print("Starting model training script...")
     if not (os.path.exists(X_path) and os.path.exists(y_path)):
         print(f"Error: Processed data not found at {X_path} or {y_path}.")
@@ -24,7 +55,16 @@ def run_training(
         )
         return None, None
 
-    model_path, run_id = train_churn_model(X_path, y_path)
+    model_path, run_id = train_churn_model(
+        X_path,
+        y_path,
+        solver=solver,
+        C=C,
+        penalty=penalty,
+        random_state=random_state,
+        max_iter=max_iter,
+        test_size=test_size,
+    )
     print(f"Training complete. Model saved to: {model_path}")
     print(f"MLflow Run ID: {run_id}")
     return model_path, run_id
@@ -41,9 +81,52 @@ def main():
         default=PROCESSED_TARGET_PATH,
         help="Path to processed target CSV",
     )
+    parser.add_argument(
+        "--solver",
+        default="liblinear",
+        help="Logistic regression solver",
+    )
+    parser.add_argument(
+        "--C",
+        type=float,
+        default=1.0,
+        help="Inverse of regularization strength",
+    )
+    parser.add_argument(
+        "--penalty",
+        default="l2",
+        help="Penalty (regularization) type",
+    )
+    parser.add_argument(
+        "--random_state",
+        type=int,
+        default=42,
+        help="Random state for reproducibility",
+    )
+    parser.add_argument(
+        "--max_iter",
+        type=int,
+        default=100,
+        help="Maximum number of training iterations",
+    )
+    parser.add_argument(
+        "--test_size",
+        type=float,
+        default=0.2,
+        help="Proportion of the dataset to use for testing",
+    )
     args = parser.parse_args()
 
-    run_training(args.X_path, args.y_path)
+    run_training(
+        args.X_path,
+        args.y_path,
+        solver=args.solver,
+        C=args.C,
+        penalty=args.penalty,
+        random_state=args.random_state,
+        max_iter=args.max_iter,
+        test_size=args.test_size,
+    )
 
 if __name__ == '__main__':
     main()

--- a/tests/test_monitor_performance.py
+++ b/tests/test_monitor_performance.py
@@ -88,5 +88,24 @@ class TestMonitorPerformance(unittest.TestCase):
         finally:
             os.environ.pop('CHURN_THRESHOLD', None)
 
+    def test_monitor_custom_paths(self):
+        from unittest.mock import patch
+
+        with patch('src.monitor_performance.evaluate_model', return_value=(0.5, 0.5)) as mock_eval, patch(
+            'src.monitor_performance.train_churn_model'
+        ) as mock_train:
+            monitor_and_retrain(
+                threshold=0.6,
+                X_path='custom_X.csv',
+                y_path='custom_y.csv',
+            )
+            mock_eval.assert_called_once_with(
+                MODEL_PATH, 'custom_X.csv', 'custom_y.csv'
+            )
+            mock_train.assert_called_once()
+            args = mock_train.call_args.args
+            self.assertEqual(args[0], 'custom_X.csv')
+            self.assertEqual(args[1], 'custom_y.csv')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_run_evaluation.py
+++ b/tests/test_run_evaluation.py
@@ -67,6 +67,22 @@ class TestRunEvaluation(unittest.TestCase):
         self.assertTrue(os.path.exists(MODEL_PATH))
         self.assertTrue(os.path.exists(output_file))
 
+    def test_run_evaluation_detailed(self):
+        train_churn_model(self.X_path, self.y_path)
+        output_file = os.path.join(self.tmpdir, 'metrics_detailed.json')
+        acc, f1, report = run_evaluation(
+            MODEL_PATH,
+            self.X_path,
+            self.y_path,
+            output_file,
+            detailed=True,
+        )
+        self.assertTrue(os.path.exists(output_file))
+        self.assertIsInstance(report, dict)
+        with open(output_file) as f:
+            data = json.load(f)
+        self.assertIn('classification_report', data)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_run_monitor.py
+++ b/tests/test_run_monitor.py
@@ -60,6 +60,58 @@ class TestRunMonitor(unittest.TestCase):
         finally:
             sys.argv = old_argv
 
+    def test_monitor_custom_params_forwarded(self):
+        from unittest.mock import patch
+
+        with patch('src.monitor_performance.train_churn_model') as mock_train:
+            import sys
+            old_argv = sys.argv
+            sys.argv = [
+                'run_monitor.py',
+                '--threshold', '0.0',
+                '--solver', 'saga',
+                '--C', '0.9',
+                '--penalty', 'l1',
+                '--random_state', '99',
+                '--max_iter', '150',
+                '--test_size', '0.3',
+            ]
+            try:
+                main()
+                mock_train.assert_called()
+                kwargs = mock_train.call_args.kwargs
+                self.assertEqual(kwargs['solver'], 'saga')
+                self.assertAlmostEqual(kwargs['C'], 0.9)
+                self.assertEqual(kwargs['penalty'], 'l1')
+                self.assertEqual(kwargs['random_state'], 99)
+                self.assertEqual(kwargs['max_iter'], 150)
+                self.assertAlmostEqual(kwargs['test_size'], 0.3)
+            finally:
+                sys.argv = old_argv
+
+    def test_monitor_custom_paths(self):
+        from unittest.mock import patch
+
+        with patch('src.monitor_performance.train_churn_model') as mock_train, patch(
+            'src.monitor_performance.evaluate_model', return_value=(0.5, 0.5)
+        ):
+            import sys
+            old_argv = sys.argv
+            sys.argv = [
+                'run_monitor.py',
+                '--threshold', '0.6',
+                '--X_path', 'custom_X.csv',
+                '--y_path', 'custom_y.csv',
+            ]
+            try:
+                main()
+                mock_train.assert_called()
+                args = mock_train.call_args.args
+                self.assertEqual(args[0], 'custom_X.csv')
+                self.assertEqual(args[1], 'custom_y.csv')
+            finally:
+                sys.argv = old_argv
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_run_pipeline.py
+++ b/tests/test_run_pipeline.py
@@ -6,6 +6,8 @@ import mlflow
 
 from scripts.run_pipeline import run_pipeline
 from src.train_model import MODEL_PATH
+import joblib
+
 
 class TestRunPipeline(unittest.TestCase):
     def setUp(self):
@@ -26,5 +28,38 @@ class TestRunPipeline(unittest.TestCase):
         self.assertIsInstance(acc, float)
         self.assertIsInstance(f1, float)
 
-if __name__ == '__main__':
+    def test_pipeline_custom_params(self):
+        acc, f1 = run_pipeline(
+            solver="liblinear",
+            C=0.6,
+            penalty="l1",
+            random_state=123,
+            max_iter=150,
+            test_size=0.3,
+        )
+        self.assertTrue(os.path.exists(MODEL_PATH))
+        model = joblib.load(MODEL_PATH)
+        params = model.get_params()
+        self.assertEqual(params["solver"], "liblinear")
+        self.assertAlmostEqual(params["C"], 0.6)
+        self.assertEqual(params["penalty"], "l1")
+        self.assertEqual(params["random_state"], 123)
+        self.assertEqual(params["max_iter"], 150)
+
+    def test_test_size_forwarded(self):
+        from unittest.mock import patch
+
+        with patch(
+            "scripts.run_pipeline.run_training",
+            return_value=(MODEL_PATH, "run"),
+        ) as mock_training, patch(
+            "scripts.run_pipeline.run_evaluation", return_value=(0.0, 0.0)
+        ):
+            run_pipeline(test_size=0.25, penalty="l1")
+            mock_training.assert_called_once()
+            self.assertAlmostEqual(mock_training.call_args.kwargs["test_size"], 0.25)
+            self.assertEqual(mock_training.call_args.kwargs["penalty"], "l1")
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_training.py
+++ b/tests/test_run_training.py
@@ -10,8 +10,8 @@ from src.train_model import MODEL_PATH
 
 class TestRunTraining(unittest.TestCase):
     def setUp(self):
-        self.X_path = 'data/processed/processed_features.csv'
-        self.y_path = 'data/processed/processed_target.csv'
+        self.X_path = "data/processed/processed_features.csv"
+        self.y_path = "data/processed/processed_target.csv"
         if os.path.exists(MODEL_PATH):
             os.remove(MODEL_PATH)
         self.tmpdir = tempfile.mkdtemp()
@@ -28,6 +28,39 @@ class TestRunTraining(unittest.TestCase):
         self.assertTrue(os.path.exists(model_path))
         self.assertIsInstance(run_id, str)
 
+    def test_run_training_custom_params(self):
+        model_path, run_id = run_training(
+            self.X_path,
+            self.y_path,
+            solver="liblinear",
+            C=0.7,
+            penalty="l1",
+            random_state=123,
+            max_iter=150,
+            test_size=0.3,
+        )
+        self.assertTrue(os.path.exists(model_path))
+        import joblib
 
-if __name__ == '__main__':
+        model = joblib.load(model_path)
+        params = model.get_params()
+        self.assertAlmostEqual(params["C"], 0.7)
+        self.assertEqual(params["penalty"], "l1")
+        self.assertEqual(params["random_state"], 123)
+        self.assertEqual(params["max_iter"], 150)
+
+    def test_test_size_forwarded(self):
+        from unittest.mock import patch
+
+        with patch(
+            "scripts.run_training.train_churn_model",
+            return_value=(MODEL_PATH, "run"),
+        ) as mock_train:
+            run_training(self.X_path, self.y_path, test_size=0.3, penalty="l1")
+            mock_train.assert_called_once()
+            self.assertAlmostEqual(mock_train.call_args.kwargs["test_size"], 0.3)
+            self.assertEqual(mock_train.call_args.kwargs["penalty"], "l1")
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `run_monitor.py` to override dataset paths with `--X_path` and `--y_path`
- forward those paths through `monitor_and_retrain`
- document the new options in README
- add unit tests for custom paths when monitoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c757c41e48329b6f2eef77d9093fc

## Summary by Sourcery

Expose dataset path overrides and full hyperparameter configurability across monitoring, training, pipeline, and evaluation scripts; enable optional detailed classification reports; update documentation and add tests to cover new options.

New Features:
- Expose --X_path and --y_path flags in the monitoring script and monitor_and_retrain function
- Add CLI options for logistic regression hyperparameters (solver, C, penalty, random_state, max_iter, test_size) across run_training, run_monitor, run_pipeline, and run_evaluation scripts
- Introduce a --detailed flag in evaluation scripts to generate and log a full classification report

Enhancements:
- Propagate hyperparameter arguments through train_churn_model, monitor_and_retrain, and pipeline workflows
- Extend evaluate_model to optionally return and log classification reports when detailed=True

Documentation:
- Update README with new CLI flags and usage examples for custom paths, hyperparameters, and detailed evaluation reports

Tests:
- Add unit tests to verify custom dataset paths and hyperparameter forwarding in monitoring, training, pipeline, model training, and evaluation modules